### PR TITLE
Fix composer.json: Correct path to docxmlrpcs.inc in autoload/classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
             "jsonrpc/jsonrpcs.inc",
             "proxy/proxyxmlrpcs.inc",
             "xmlrpc_extension_api/xmlrpc_extension_api.inc",
-            "docxmlrpcs.inc"
+            "docxmlrpcserver/docxmlrpcs.inc"
         ]
     },
     "require":


### PR DESCRIPTION
This fixes
```
[RuntimeException]
Could not scan for classes inside "/[…]/vendor/phpxmlrpc/extras/docxmlrpcs.inc"
which does not appear to be a file nor a folder
```
when trying to install `phpxmlrpc/extras` using composer.